### PR TITLE
use flow router 2 and a nav bar fix

### DIFF
--- a/components/ionNavBar/ionNavBar.js
+++ b/components/ionNavBar/ionNavBar.js
@@ -99,6 +99,24 @@ Template.ionNavBar.destroyed = function () {
 };
 
 Template.ionNavBar.helpers({
+  headerButtonLeft: function () {
+    var parentFunction = Template.parentData(1).headerButtonLeft
+    if (parentFunction) {
+      return parentFunction()
+    }
+  },
+  headerTitle: function () {
+    var parentFunction = Template.parentData(1).headerTitle
+    if (parentFunction) {
+      return parentFunction()
+    }
+  },
+  headerButtonRight: function () {
+    var parentFunction = Template.parentData(1).headerButtonRight
+    if (parentFunction) {
+      return parentFunction()
+    }
+  },
   classes: function () {
     var classes = ['bar', 'bar-header'];
 

--- a/package.js
+++ b/package.js
@@ -12,7 +12,7 @@ Cordova.depends({
 
 Package.onUse(function(api) {
   api.versionsFrom("1.0");
-  api.use(["templating", "underscore", "fastclick", "meteorhacks:flow-router@1.9.0", "arillo:flow-router-helpers@0.4.5", "tracker", "session"], "client");
+  api.use(["templating", "underscore", "fastclick", "kadira:flow-router@2.6.2", "arillo:flow-router-helpers@0.4.5", "tracker", "session"], "client");
 
   api.addFiles([
     "vendor/snap.js",


### PR DESCRIPTION
bumped flow router to 2.6.2, everything seems to work as is. You may wish to test anyway.

There was also a bug with the nav bar. When if you added any data context it would not be able to find the Template.dynamic vars. 

In my case:

``` html
{{> ionNavBar class="bar-balanced" alignTitle='center'}}
```

This fix is not perfect but it will do the job for now. There needs to be a cleaner way to do this. Maybe a PR to BlazeLayout to fetch template name by region. 

``` js
return BlazeLayout.getRegion('headerTitle')
```
